### PR TITLE
Add WeJob.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ A curated list of awesome job boards.
 * [Zalando Jobs](https://jobs.zalando.com/en/jobs/)
 * [Euro Engineer Jobs](https://www.euroengineerjobs.com/)
 * [Careers in Poland](https://www.careersinpoland.com/)
+* [WeJob.ch](https://WeJob.ch/) (Switzerland)
 * [SwissDev Jobs](https://swissdevjobs.ch/) (Switzerland)
 * [No Fluff Jobs](https://nofluffjobs.com/) (Poland & Hungary)
 * [Duunitori](https://duunitori.fi/tyopaikat) (Finland)


### PR DESCRIPTION
Would be great to add WeJob.ch
We're the #1 Platform for Developers and IT Jobs in Switzerland

We're also available on:

- https://www.linkedin.com/company/we-job
- https://www.facebook.com/WeJobCH/
- https://twitter.com/WeJobCH
- https://t.me/wejobch/