### PR TITLE
Add Jobbsy job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 * [Jobs in JS](https://jobsinjs.com/)
 * [R-users](https://www.r-users.com/)
 * [Java Jobs](https://javajobs.pro/)
+* [Jobbsy](https://jobbsy.dev/) - Symfony job board
 
 ## Remote
 


### PR DESCRIPTION
[Jobbsy](https://jobbsy.dev) is the first and [open source](https://github.com/jobbsy-dev/jobbsy) job board dedicated to Symfony framework.