### PR TITLE
Adding Woody3 to Blockchain category

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 * [useWeb3.xyz](https://www.useweb3.xyz/jobs)
 * [BlockStryde](https://block-stryde.com/)
 * [Next Crypto Jobs](https://nextcryptojobs.com/)
-
+* [Woody3](https://www.woody3.xyz/)
 
 ## Design
 


### PR DESCRIPTION
Adding Woody3, job board exclusively dedicated to non-tech job in Web3.