### PR TITLE
Add zuhausejobs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 * [Hyper Island](https://www.hyperisland.com/jobs)
 * [findwrk](https://findwrk.app/)
 * [RemoteScout](https://remotescout.ch)
+* [zuhausejobs.com](https://zuhausejobs.com) (German-speaking area - Germany, Austria & Switzerland)
 
 ### Turkey
 

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 * [Hyper Island](https://www.hyperisland.com/jobs)
 * [findwrk](https://findwrk.app/)
 * [RemoteScout](https://remotescout.ch)
-* [zuhausejobs.com](https://zuhausejobs.com) (German-speaking area - Germany, Austria & Switzerland)
+* [zuhausejobs.com](https://zuhausejobs.com) (Remote Jobs in German-speaking area - Germany, Austria & Switzerland)
 
 ### Turkey
 


### PR DESCRIPTION
Added [zuhausejobs.com](https://zuhausejobs.com): a remote job board for the german-speaking area (Germany, Austria, Switzerland)