### PR TITLE
Added new ones for Norway

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,9 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 * [Euro Engineer Jobs](https://www.euroengineerjobs.com/)
 * [No Fluff Jobs](https://nofluffjobs.com/) | Poland & Hungary
 * [Duunitori](https://duunitori.fi/tyopaikat) | Finland
-* [Jobbland](https://jobbland.se/lediga-jobb) | Sweden
+* [jobbland.se](https://jobbland.se/lediga-jobb) | Sweden
+* [jobbland.no](https://jobbland.no/ledige-stillinger) | Norway
+* [jobbsafari.no](https://jobbsafari.no/ledige-stillinger) | Norway
 * [NIJOBS](https://www.nijobs.com/) (Ireland)
 * [Hyper Island](https://www.hyperisland.com/jobs)
 * [findwrk](https://findwrk.app/)


### PR DESCRIPTION
Added new job boards for Norway. Also changes the name for the Swedish Jobbland to distinguish it from the Norwegian Jobbland.