### PR TITLE
Remove Javajobs.pro & Add JavaProHire.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 * [JavaScript Jobs](https://jobs.date-fns.org/)
 * [Jobs in JS](https://jobsinjs.com/)
 * [R-users](https://www.r-users.com/)
-* [Java Jobs](https://javajobs.pro/)
+* [JavaProHire](https://javaprohire.com)
 * [Jobbsy](https://jobbsy.dev/) | Symfony job board
 * [Scala Jobs](https://scalajobs.com/)
 * [androidDev.careers](https://androiddev.careers) 


### PR DESCRIPTION
- I removed https://javajobs.pro because it's no longer functional.
- I added https://javaprohire.com as it is a high-quality job board exclusively for Java developers. All jobs are hand-picked, with transparent salary ranges and no intermediaries involved.