### PR TITLE
Added Statsskuld.se - Available jobs in both Swedish and English.

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 - [Euro Engineer Jobs](https://www.euroengineerjobs.com/)
 - [No Fluff Jobs](https://nofluffjobs.com/) | Poland & Hungary
 - [Duunitori](https://duunitori.fi/tyopaikat) | Finland
+- [Statsskuld.se](https://statsskuld.se/lediga-jobb) | Sweden
 - [jobbland.se](https://jobbland.se/lediga-jobb) | Sweden
 - [jobbsafari.se](https://jobbsafari.se/lediga-jobb) | Sweden
 - [jobbland.no](https://jobbland.no/ledige-stillinger) | Norway


### PR DESCRIPTION
Add Statsskuld.se to the list. Statsskuld.se offers a comprehensive overview of all Swedish job openings (in both English and Swedish), including average salary data and an assessment of how likely you are to land the role.