### PR TITLE
Update README.md - add qubitsok.com and quantum computing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 - [Startups](#startups)
 - [Free & Open Source](#open_source)
 - [DevOps](#devops)
+- [Quantum Computing](#quantum_computing)
 - [World](#world)
   - [USA](#united_states)
   - [Australia](#australia)
@@ -435,6 +436,10 @@ A curated list of awesome job boards. If you want to support my work, you can bu
 
 - [JobDevOps](https://jobdevops.com)
 - [Kube Careers](https://kube.careers)
+
+## Quantum_Computing
+
+- [qubitsok.com](https://qubitsok.com)
 
 ## World
 


### PR DESCRIPTION
Add qubitsok.com - a job board that focuses purely on quantum computing jobs. It includes personalized alerts, AI tagging of job postings. New job offers are added couple of times per week.