### PR TITLE
Update README.md - Add Top Jobs Today under Other section

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 - [Amazon Jobs](https://www.amazon.jobs/en)
 - [HackerNews Jobs](https://news.ycombinator.com/jobs)
 - [Stack Overflow Jobs](https://stackoverflow.com/jobs)
+- [Top Jobs Today](https://topjobstoday.com) - FAANG jobs
 - [Crunchboard](https://www.crunchboard.com/)
 - [Hacker Noon Jobs](https://jobs.hackernoon.com/)
 - [Jobbatical](https://jobbatical.com/jobs)


### PR DESCRIPTION
This adds https://topjobstoday.com to the "Other" section.  
Top Jobs Today focuses on fresh FAANG and big tech jobs scraped daily, helping candidates discover new openings before they hit major job boards.

Thanks for maintaining this awesome list!