### PR TITLE
chore: add findatechjob to programming boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 - [iOS Dev Jobs](https://iosdevjobs.com/)
 - [Elixir Radar](https://elixir-radar.com/jobs)
 - [Elixir Jobs](https://elixirjobs.net/)
+- [findatechjob](https://findatechjob.dev/)
 - [Full-Stack Developer Jobs](https://fullstackjob.com/)
 - [Functional Jobs](https://functionaljobs.com/)
 - [Golangprojects](https://www.golangprojects.com/)


### PR DESCRIPTION
https://findatechjob.dev is a job board aimed at developers looking for jobs in tech across the world.

It covers over 10,000 jobs from start-ups, scale-ups, larger companies and includes a fast search to quickly find what you need. I'm currently scaling the number of jobs up so expect it to get much bigger.

I've categorised it under Programming even though it does list other jobs like Engineering Manager, DevOps and SRE.