### PR TITLE
Add Remote Job Assistant to resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 - [Remote100K](https://remote100k.com/)
 - [RemoteRocketship](https://www.remoterocketship.com/)
 - [RemoteScout](https://remotescout24.com/en)
-
+- [Remote Job Assistant](https://remotejobassistant.com/) | Remote jobs for moms, career changers & non-technical professionals
 You can also check out [established-remote](https://github.com/yanirs/established-remote) for a list of established remote jobs.
 
 ## Freelancer


### PR DESCRIPTION
Adding Remote Job Assistant (https://remotejobassistant.com/) - a remote job board focused on non-technical roles for moms, career changers, and professionals seeking flexible remote work.