### PR TITLE
Add Agentic Engineering Jobs to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 
 ## AI
 
+- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Curated job board for engineers who build agentic systems: RAG pipelines, AI agents, LLM-powered products, and agent orchestration.
 - [AI Jobs](https://www.moaijobs.com/) - Find a job at a cutting-edge AI company. Filter by title, location, company, etc.
 - [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!.
 - [AI Jobs](https://ai-jobs.net/)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 
 ## AI
 
-- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). 500+ listings, free to post and free to browse.
+- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 - [AI Jobs](https://www.moaijobs.com/) - Find a job at a cutting-edge AI company. Filter by title, location, company, etc.
 - [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!.
 - [AI Jobs](https://ai-jobs.net/)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 
 ## AI
 
-- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Curated job board for engineers who build agentic systems: RAG pipelines, AI agents, LLM-powered products, and agent orchestration.
+- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). 500+ listings, free to post and free to browse.
 - [AI Jobs](https://www.moaijobs.com/) - Find a job at a cutting-edge AI company. Filter by title, location, company, etc.
 - [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!.
 - [AI Jobs](https://ai-jobs.net/)


### PR DESCRIPTION
Adding https://agentic-engineering-jobs.com — a job board for engineers building agentic systems (RAG pipelines, AI agents, LLM-powered products, agent orchestration).

- 500+ active listings
- Free to post for companies, free to browse for job seekers
- Remote and global roles
- Placed in alphabetical order in the AI section

Happy to adjust description length or placement if needed.