### PR TITLE
Add AI Dev Jobs to AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 ## AI
 
 - [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+- [AI Dev Jobs](https://aidevboard.com) - The specialized job board for AI/ML developers. 5000+ curated roles with salary data and a REST API for agents.
 - [AI Jobs](https://www.moaijobs.com/) - Find a job at a cutting-edge AI company. Filter by title, location, company, etc.
 - [AI/ML Jobs](https://aimljobs.fyi) - Jobs at Top AI Companies and Startups, Updated Daily!.
 - [AI Jobs](https://ai-jobs.net/)


### PR DESCRIPTION
Adding [AI Dev Jobs](https://aidevboard.com) to the AI section.

- Specialized job board exclusively for AI/ML developer roles
- 5,000+ curated positions from 250+ companies
- Salary data on 2,100+ listings
- REST API for programmatic access
- Free to browse