### PR TITLE
fix: Add usdevjobs.com to Job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [Remote Physician Jobs](https://www.remotephysicianjobs.org/) - Remote jobs for physicians and doctors. Live aggregator of 600 companies' job boards, updated daily.
 - [Library Jobs HQ](https://www.libraryjobshq.com/)
 - [FoundRole](https://foundrole.com/) - AI-powered job search platform and job application tracker for knowledge workers.
+- [USDevJobs](https://usdevjobs.com/) - Real-time job aggregator for software, AI/ML, and data engineer roles at US startups.
 
 ### Australia
 


### PR DESCRIPTION
Please Adds [US Dev Jobs](https://usdevjobs.com/) to the Job boards section.

- 1,000+ Software, AI/ML, Data engineering roles from US startups daily.
- Aggregated only US jobs from Linkedin, Indeed, recruiting/staffing agencies.
- The job list is updated hourly.
- Filter by remote , title, url, company, date.

Thank you for maintaining this list!