### PR TITLE
Add web3vacancy to Blockchain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can also check out [easy-application](https://github.com/j-delaney/easy-appl
 - [Jobstash](https://jobstash.xyz/jobs)
 - [BeInCrypto Jobs](https://beincrypto.com/jobs/)
 - [Sail on Chain](https://sailonchain.com/)
+- [web3vacancy](https://web3vacancy.com/) — Crypto-native job board aggregating 2,400+ roles from DeFi, L2s, wallets, and infrastructure companies. Updated every 5 minutes.
 
 ## Design
 


### PR DESCRIPTION
Adds [web3vacancy](https://web3vacancy.com) to the Blockchain section. It's a crypto-native job board aggregating 2,400+ live roles from DeFi protocols, L2 networks, wallet providers, and infrastructure companies, updated every 5 minutes. Fits alongside Crypto Jobs List, web3.career, Cryptocurrency Jobs, and Remote3 already in the list.