### PR TITLE
Add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [Eluta](https://www.eluta.ca/)
 - [CareerBeacon](https://www.careerbeacon.com/)
 - [CanadianNanny.ca](https://canadiannanny.ca/)
+- [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student and recent-grad jobs across internships, co-ops, new grad, junior, and entry-level roles.
 - [MapleStack](https://maplestack.ca/) - Canadian jobs with AI-powered matching
 
 ### UK


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Canada section.
- It is a daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across fields.

Thanks for maintaining this list!