### PR TITLE
Add warpjobs to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You can also check out the following resources:
 - [JobsByCulture](https://jobsbyculture.com/) - Culture-first AI & tech job board with Glassdoor ratings, culture values, and employee reviews for 45+ companies.
 - [Jobtensor](https://jobtensor.com/) - AI, tech, and science job board.
 - [AimVantage](https://aimvantage.uk) - AI-powered interview preparation and job search tool with 20+ free career tools.
+- [warpjobs](https://warpjobs.com) - Niche board of GPU/CUDA, ML-systems, inference & performance-engineering roles, scraped daily from AI-lab & infra companies' ATS feeds (Greenhouse/Lever/Ashby); free, open-source, RSS/JSON feeds.
 
 ## Data
 


### PR DESCRIPTION
Adds **warpjobs** (https://warpjobs.com) to the AI section.

A free, niche job board for **GPU/CUDA, ML-systems, inference and performance-engineering** roles, aggregated daily from AI-lab and infra companies' public ATS feeds (Greenhouse / Lever / Ashby) - more specialized than the general AI boards already listed. Open-source scraper, RSS + JSON feeds, no login or paywall. ~115 live roles from 23 companies. Appended to the AI section, format-matched.
