### PR TITLE
Add SwissAIJob to Switzerland section

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [WeJob.ch](https://WeJob.ch/)
 - [Jobwinner](https://jobwinner.ch/en/)
 - [JobScout24](https://www.jobscout24.ch/en)
+- [SwissAIJob](https://swissaijob.ch/)
 
 ### Sweden
 


### PR DESCRIPTION
Adds [SwissAIJob](https://swissaijob.ch/) to the Switzerland section.

SwissAIJob is a job board aggregating AI and ML roles in Switzerland across both industry and academia. It currently lists ~370 active positions, refreshed every 3 days from employer career pages (no recruiter spam). All roles include direct apply links, salary estimates, and CV-matching against the active listings.

Adding to the bottom of the Switzerland section, matching the existing entry format.