### PR TITLE
Add Hanzilla Jobs to Canada job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [CareerBeacon](https://www.careerbeacon.com/)
 - [CanadianNanny.ca](https://canadiannanny.ca/)
 - [MapleStack](https://maplestack.ca/) - Canadian jobs with AI-powered matching
+- [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student and recent-graduate jobs across internships, co-ops, new grad, junior, and entry-level roles.
 
 ### UK
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Canada section.
- Hanzilla Jobs is a free, daily-updated Canadian student/recent-graduate job board for internships, co-ops, new grad, junior, and entry-level roles across fields.

## Why it fits
- Canada-specific job board.
- Focused on students and early-career candidates, which complements the existing general Canada job-board links.
