### PR TITLE
docs: remove duplicate Hanzilla Jobs entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,6 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [CanadianNanny.ca](https://canadiannanny.ca/)
 - [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student and recent-grad jobs across internships, co-ops, new grad, junior, and entry-level roles.
 - [MapleStack](https://maplestack.ca/) - Canadian jobs with AI-powered matching
-- [Hanzilla Jobs](https://jobs.hanzilla.co/) - Daily-updated Canadian student and recent-graduate jobs across internships, co-ops, new grad, junior, and entry-level roles.
 
 ### UK
 


### PR DESCRIPTION
## Summary
- Removes the duplicate Hanzilla Jobs row from the Canada section.
- Keeps the existing Canada-specific entry that was already accepted.

## Context
I noticed the same resource appears twice after two previous accepted PRs (#164 and #173). This keeps the list tidy and avoids maintainer/user confusion.

## Test plan
- Markdown-only cleanup.
- Verified the remaining Hanzilla Jobs URL is still present once in the Canada section.
