### PR TITLE
docs: add State of ATS 2026 dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You can also check out the following resources:
 
 - [easy-application](https://github.com/j-delaney/easy-application) - Over 400 software engineering companies that are easy to apply to.
 - [ATSGuard](https://atsguard.com) - Scans your resume against any JD before you apply.
+- [State of ATS 2026](https://github.com/Kayvan-Zahiri/state-of-ats-2026) - Hand-verified dataset of which ATS the 743 largest employers use. F500 + Global 2000 + Series-C+ private $1B+. MIT.
 
 ## AI
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can also check out the following resources:
 - [Resume Roaster](https://resume.roastlabai.com) - AI resume roast with ATS scoring that grades your resume against a job description and flags missing keywords.
 - [Cviya](https://cviya.com) - A fully customizable, watermark-free resume builder featuring native RTL support and multilingual capabilities for global professionals.
 - [JobFit](https://github.com/andrwspt/jobfit) - Free offline resume gap checker — paste your resume + job description, get match score and missing keywords. 100% browser-based, no server, no tracking.
+- [State of ATS 2026](https://github.com/Kayvan-Zahiri/state-of-ats-2026) - Hand-verified dataset of which ATS the 743 largest employers use. F500 + Global 2000 + Series-C+ private $1B+. MIT.
 
 ## AI
 


### PR DESCRIPTION
Adds State of ATS 2026, a hand-verified open dataset of which Applicant Tracking System each of the 743 largest employers uses (Fortune 500 + Global 2000 + Series-C+ private \$1B+). MIT licensed, also published as an npm package and raw CSV.

Useful for job seekers tailoring resumes per ATS family, HR/recruiting researchers, and anyone studying enterprise SaaS market share.

Repo: https://github.com/Kayvan-Zahiri/state-of-ats-2026
npm: @withresumeai/ats-data