### PR TITLE
Update README.md, add CEEhire to Europe section

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [teletravail.guru](https://teletravail.guru) - Full remote for frenchies, Emplois 100% télétravail depuis la France.
 - [DefenceJobs.org](https://www.defencejobs.org/) - Jobs in European defence industry 🇪🇺 
 - [huntas.lt](https://huntas.lt) - All jobs in Lithuania.
+- [CEEhire](https://ceehire.com) - Validated remote IT jobs from US/UK companies for Central & Eastern European tech talent. Transparent salaries, no ghost jobs.
 
 ### Turkey
 


### PR DESCRIPTION
CEEhire focuses on a completely underserved niche: connecting US/UK companies with verified remote IT talent from Central & Eastern Europe. All listings are recruiter-validated (no ghost jobs), salaries are transparent. No similar board exists in this list for the CEE region.