### PR TITLE
Add CreatorJobBoard to Freelance

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ You can also check out [established-remote](https://github.com/yanirs/establishe
 - [YunoJuno](https://www.yunojuno.com/)
 - [Gun.io](https://www.gun.io/)
 - [Freel](https://www.freel.ca/) - Freelancing jobs in Canada.
+- [CreatorJobBoard](https://creatorjobboard.com) — Job board for the creator economy, featuring video editing, design, social media, UGC, and growth roles.
 
 ## Fashion
 


### PR DESCRIPTION
Adds CreatorJobBoard, a job board for the creator economy, featuring video editing, design, social media, UGC, and growth roles.

Happy to adjust placement or wording if needed.