### PR TITLE
Add DACH Early-Career Jobs to Germany section

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [meinestadt](https://www.meinestadt.de/)
 - [karrieresprung](https://www.karrieresprung.de/)
 - [JobJump](https://jobjump.net/)
+- [DACH Early-Career Jobs](https://github.com/heynish/werkstudent-praktikum-jobs)
 
 ### Netherlands
 


### PR DESCRIPTION
Adds an auto-updating job board for early-career roles (Werkstudent, Praktikum, Absolvent/new-grad) across Germany, Austria & Switzerland.

- ~1,000 live roles, refreshed daily via GitHub Action
- Sourced from public company ATS APIs (Greenhouse/Lever/Ashby/Personio) + the German Federal Employment Agency
- Free, no signup; every listing links to the original posting

Fits alongside the existing German boards (Berlin Startup Jobs, GermanTech Jobs). Thanks for maintaining the list!