### PR TITLE
Add Remote PM Jobs to Product section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ You can also check out [established-remote](https://github.com/yanirs/establishe
 - [APM List](https://apmlist.com/) - Specialized for Associate PM roles and internships.
 - [Best PM Jobs](https://www.bestpmjobs.com/)
 - [Mind the Product](https://www.mindtheproduct.com/jobs/) - A well-known job board for product managers and designers.
+- [Remote PM Jobs](https://remotepmjobs.com/) - Remote-only product manager jobs pulled directly from company ATSs and verified fully remote, with posted salary data.
 
 ## Freelancer
 


### PR DESCRIPTION
Adds Remote PM Jobs (remotepmjobs.com), a free job board for remote-only product manager roles. Every listing is pulled directly from the company's ATS (Greenhouse, Lever, Ashby, Workday, etc.) and verified fully remote, with closed roles removed daily so there are no ghost jobs. Most live listings include posted salary ranges.

Entry added alphabetically to the Product section, matching the format of neighboring entries.