### PR TITLE
Add ChainJobs to Blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ You can also check out the following resources:
 - [web3vacancy](https://web3vacancy.com/) — Crypto-native job board aggregating 2,400+ roles from DeFi, L2s, wallets, and infrastructure companies. Updated every 5 minutes.
 - [PredictionJobs](https://predictionjobs.co) — Job board for the prediction market space, featuring roles at Polymarket, Kalshi etc.
 - [Jobs in Crypto](https://jobsincrypto.xyz) - Marketplace for crypto, web3, and onchain roles.
+- [ChainJobs](https://chainjobs.io/) — Crypto, web3 and blockchain roles aggregated daily from companies' official careers pages; every listing links to the employer's own application page.
 
 ## Design
 


### PR DESCRIPTION
Adds [ChainJobs](https://chainjobs.io/) to the Blockchain section.

ChainJobs aggregates crypto, web3 and blockchain roles directly from companies' official careers pages (Greenhouse, Lever, Ashby) and re-verifies them daily — roles removed at the source are removed here the same day. Currently ~2,470 live roles across 122 companies.

Every listing links to the employer's own application page rather than an internal apply flow, and non-technical roles (marketing, BD, community, operations) are surfaced alongside engineering. Salary bands are shown only where the employer publishes them.

Entry appended to the end of the Blockchain section, matching the format of the surrounding entries.