### PR TITLE
Add Global Remote Hub to Remote section

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ You can also check out the following resources:
 - [Corvi Careers Remote](https://corvi.careers/remote-jobs/) - Remote jobs categorized by profession.
 - [FindRemoteAccountingJobs](https://findremoteaccountingjobs.com/) - Remote jobs for accounting and finance professionals.
 - [Remote1stJobs](https://www.remote1stjobs.com/) - UK, Europe & EMEA remote-first jobs board; filters out US-only and fake-remote roles, direct employer links, salary-visible.
+- [Global Remote Hub](https://globalremotehub.com/) - Remote & relocation jobs requiring German, French, or Spanish. For bilingual candidates.
 
 You can also check out [established-remote](https://github.com/yanirs/established-remote) for a list of established remote jobs.
 


### PR DESCRIPTION
Adds Global Remote Hub to the Remote section — a free job board for bilingual candidates, listing remote and relocation roles that require German, French, or Spanish. Matches the existing entry format; one addition, no deletions.