### PR TITLE
Add Landed to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You can also check out the following resources:
 - [Jobtensor](https://jobtensor.com/) - AI, tech, and science job board.
 - [AimVantage](https://aimvantage.uk) - AI-powered interview preparation and job search tool with 20+ free career tools.
 - [warpjobs](https://warpjobs.com) - Niche board of GPU/CUDA, ML-systems, inference & performance-engineering roles, scraped daily from AI-lab & infra companies' ATS feeds (Greenhouse/Lever/Ashby); free, open-source, RSS/JSON feeds.
+- [Landed](https://landed.jobs) - Daily matched AI-native roles with fit scores and drafted application answers, plus interview prep. Free tier; also queryable from any editor via a public MCP server.
 
 ## Data
 


### PR DESCRIPTION
Adds Landed to the AI section.

[Landed](https://landed.jobs) matches AI-native roles daily with a fit score and a short reason, drafts answers to the screening questions on each application, and includes interview prep. There is a free tier.

It is also queryable from any MCP client at `https://mcp.landed.jobs/mcp`, so you can search roles and pull an application form without leaving your editor. Listed on the Official MCP Registry as `io.github.landedjobs/landed`.

Link verified working. Entry added at the end of the section, matching the existing format.
