### PR TITLE
Add AI Applyd (Germany + tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ You can also check out the following resources:
 - [CVCheck](https://cvcheck.app) - Scores your CV across 7 recruiter criteria instead of a single ATS match percentage.
 - [ApplyKit](https://applykit-beryl.vercel.app) - AI resume tailoring, cover letter, and interview prep built from your actual background.
 - [PrepNPlaced](https://www.prepnplaced.com/ats-resume-checker) - Free ATS resume check that scores your resume against a specific job description.
+- [AI Applyd](https://aiapplyd.com) - Submits on the employer's own careers page and reports back the status their ATS returns, including failures.
 
 ## AI
 
@@ -570,6 +571,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 
 - [Jobsuche](https://www.jobsintown.de/jobsuche/)
 - [StepStone](https://www.stepstone.de/en)
+- [AI Applyd](https://aiapplyd.com/jobs)
 - [jobvector](https://www.jobvector.de/en/)
 - [Jobware](https://www.jobware.de/)
 - [Stellenanzeigen](https://www.stellenanzeigen.de/)


### PR DESCRIPTION
Two entries, both matching the style already used in their sections.

**Germany** — added as a bare link, like the other boards in that section. It is a German-language browse surface; the roles are pulled from employers' own applicant tracking systems (Greenhouse, Workday, Personio, Teamtailor) rather than re-hosted from another aggregator.

**Tools block** — added alongside ATSGuard, CVCheck, ApplyKit and PrepNPlaced, with a one-line factual description in the same plain style. The thing that makes it different from the resume-scoring tools already listed is the submission half: it submits on the employer's own careers page and reports back the status their ATS returns, including when an application fails.

Disclosure: I work on it. Happy to reword, shorten, or drop either entry if it does not fit the list. Both links are live and return 200.