### PR TITLE
Add CrawlJobs to General section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A curated list of awesome job boards. If you want to support my work, you can [b
 - [X jobs](https://x.com/jobs)
 - [JobYap](https://jobyap.com) - Search job postings aggregated from companies' official careers sites — salaries, locations, and a community discussion thread on every job.
 - [Open Jobs Search](https://conorscode.github.io/open-jobs-search/) - Free search over 37,000+ live postings from 378 companies across nine ATS platforms (Greenhouse, Lever, Ashby, Workday, and more). No signup, no ads, no tracking.
+- [CrawlJobs](https://crawljobs.com) - Global job board with 550,000+ active listings crawled directly from employers' own career pages instead of other job boards. Covers 200+ countries in 20+ language versions, with filters for location, work mode and salary.
 
 You can also check out the following resources:
 


### PR DESCRIPTION
Adds CrawlJobs to the General section.

CrawlJobs is a global job board that crawls listings directly from employers' own career pages rather than re-listing them from other job boards, so it surfaces roles that never reach the big aggregators. Currently 550,000+ active listings across 200+ countries, available in 20+ language versions, with filters for location, work mode and salary.