### PR TITLE
Add Maneki to Blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can also check out the following resources:
 - [PredictionJobs](https://predictionjobs.co) — Job board for the prediction market space, featuring roles at Polymarket, Kalshi etc.
 - [Jobs in Crypto](https://jobsincrypto.xyz) - Marketplace for crypto, web3, and onchain roles.
 - [ChainJobs](https://chainjobs.io/) — Crypto, web3 and blockchain roles aggregated daily from companies' official careers pages; every listing links to the employer's own application page.
+- [Maneki](https://maneki.work/) — Web3 jobs from 500+ companies' career pages, refreshed nightly; normalized salary data, remote filters, expired listings removed automatically.
 
 ## Design
 


### PR DESCRIPTION
Adding [Maneki](https://maneki.work) to the Blockchain section.

Disclosure: I built it. Web3 job aggregator pulling listings nightly from 500+ companies' own career pages (not pay-to-post), with normalized salary data, remote filters, and automatic removal of listings that go offline. Free, no signup — applying always links to the employer's own posting.