### PR TITLE
Add Russia subsection to World with Joba Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A curated list of awesome job boards. If you want to support my work, you can [b
   - [Asia](#asia)
   - [Latam](#latam)
   - [Africa](#africa)
+  - [Russia](#russia)
 
 ## General
 
@@ -700,3 +701,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 ### Africa
 
 - [Jobberman Nigeria](https://jobberman.com)
+
+### Russia
+
+- [Joba Search](https://t.me/joba_search_bot) - Telegram bot aggregating game-industry jobs from Russian-language channels.


### PR DESCRIPTION
Adds a `### Russia` subsection under World (also added to Contents) with [Joba Search](https://t.me/joba_search_bot) — a Telegram bot that aggregates game-industry job postings from Russian-language channels. In Russia most game-industry hiring happens in Telegram channels rather than on classic web boards, so a Telegram-native aggregator is the practical entry point for this market. Disclosure: I am the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)