### PR TITLE
Add India section with PrepNPlaced Apprenticeships

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A curated list of awesome job boards. If you want to support my work, you can [b
   - [Malta](#malta)
   - [Turkey](#turkey)
   - [UAE](#uae)
+  - [India](#india)
   - [Asia](#asia)
   - [Latam](#latam)
   - [Africa](#africa)
@@ -686,6 +687,10 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [Remote Jobs in Dubai](https://www.remotedxb.com)
 - [JobXDubai](https://jobxdubai.com)
 - [Zero Tax Jobs](https://zerotaxjobs.com/)
+
+### India
+
+- [PrepNPlaced Apprenticeships](https://www.prepnplaced.com/apprenticeships) - Hand-checked Indian tech apprenticeship and early-career programmes, including government and PSU schemes.
 
 ### Asia
 


### PR DESCRIPTION
Adds an **India** section under `## World`, placed between UAE and Asia, plus the matching TOC entry.

India currently has no section — Asia holds a single Vietnam entry — so Indian readers have nowhere to look. Following the pattern of the recently added Malta section.

**Entry:**

- [PrepNPlaced Apprenticeships](https://www.prepnplaced.com/apprenticeships) - Hand-checked Indian tech apprenticeship and early-career programmes, including government and PSU schemes.

**About the listing**

- Free to browse, no account or signup needed
- Currently 365 live programmes, each checked by hand against the official posting rather than scraped
- Covers government and PSU schemes (ISRO, DRDO, IOCL) alongside private employers — these are scattered across dozens of separate portals and are hard to find in one place
- Every entry links out to the employer's own application page

Two lines changed, nothing else touched.