### PR TITLE
Add JobFit to career tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You can also check out the following resources:
 - [AI Applyd](https://aiapplyd.com) - Submits on the employer's own careers page and reports back the status their ATS returns, including failures.
 - [Resume Roaster](https://resume.roastlabai.com) - AI resume roast with ATS scoring that grades your resume against a job description and flags missing keywords.
 - [Cviya](https://cviya.com) - A fully customizable, watermark-free resume builder featuring native RTL support and multilingual capabilities for global professionals.
+- [JobFit](https://github.com/andrwspt/jobfit) - Free offline resume gap checker — paste your resume + job description, get match score and missing keywords. 100% browser-based, no server, no tracking.
 
 ## AI
 


### PR DESCRIPTION
## Description
Add JobFit to the career tools section.

JobFit is a free offline resume gap checker — paste your resume + job description, get match score and missing keywords. 100% browser-based, no server, no tracking.

- Link: https://github.com/andrwspt/jobfit
- MIT licensed
- Perfect for job seekers who want to check their resume match without uploading to a server