### PR TITLE
Add GMI Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You can also check out the following resources:
 - [CryptoJobs](https://crypto.jobs/)
 - [Blockew](https://blockew.com/)
 - [Cryptocurrency Jobs](https://cryptocurrencyjobs.co/)
+- [GMI Jobs](https://gmijobs.com/)
 - [JobsInBlockchain](https://jobsinblockchain.com/)
 - [Web3 Jobs](https://web3.career/)
 - [token jobs](https://tokenjobs.io)


### PR DESCRIPTION
Adding [GMI Jobs](https://gmijobs.com) — crypto/Web3 job board with live roles from 230+ companies via employer ATS feeds, salary and token-compensation data shown on listings. Entry follows the existing format of the list.