### PR TITLE
Add First Look Jobs to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can also check out the following resources:
 - [AimVantage](https://aimvantage.uk) - AI-powered interview preparation and job search tool with 20+ free career tools.
 - [warpjobs](https://warpjobs.com) - Niche board of GPU/CUDA, ML-systems, inference & performance-engineering roles, scraped daily from AI-lab & infra companies' ATS feeds (Greenhouse/Lever/Ashby); free, open-source, RSS/JSON feeds.
 - [Landed](https://landed.jobs) - Daily matched AI-native roles with fit scores and drafted application answers, plus interview prep. Free tier; also queryable from any editor via a public MCP server.
+- [First Look Jobs](https://firstlookjobs.com) - Directory of remote AI training and domain-expert jobs from six referral programs (Mercor, micro1, Turing, Alignerr, Contra, Handshake AI). Advertised pay, weekly hours and country eligibility parsed per listing; hourly contracts, $6-$400/hr.
 
 ## Data
 


### PR DESCRIPTION
Adds First Look Jobs to the AI section.

A directory of remote jobs from six programmes that hire people to train and evaluate AI systems — Mercor, micro1, Turing, Alignerr, Contra and Handshake AI. Every live listing is re-scraped daily.

**What it adds that the section doesn't already have:** per-listing country eligibility. The programmes publish their own eligibility rules and the site parses them, so you can filter to jobs actually open to applicants in your country instead of reading "Remote" and finding out after applying. It also publishes original measurements over the whole catalogue at /research — for example, that 114 of the 262 listings which publish a weekly hours commitment ask for less than full time.

No signup, no paywall, no login. Every job links out to the programme's own application.

**Disclosure:** the site is monetised through the programmes' referral schemes and earns a commission if a listed programme hires someone, disclosed in the site footer. Noting it explicitly since it's the business model — same as Gridnaut Recruiting, already in this section.