### PR TITLE
Add Robot Jobs Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can also check out the following resources:
 - [Gridnaut Recruiting](https://gridnaut.site/jobs/) - Curated AI training, evaluation, and domain-expert contractor roles (Mercor referrals). 100% remote, hourly contracts ($23-$180/hr).
 - [Human Pages](https://humanpages.ai) - The open directory AI agents use to hire humans for real-world tasks. Zero platform fees
 - [Jobs in AI](https://jobsinai.com) - Marketplace for AI, machine learning, data science, and AI agent roles.
+- [Robot Jobs Board](https://www.robotjobsboard.com) - Robotics and automation roles (AMR, humanoid, drones, ROS) across US, UK, and Europe.
 - [Vibehackers Jobs](https://vibehackers.io/jobs) - Job board for vibe coders and AI-assisted development roles.
 - [JobsByCulture](https://jobsbyculture.com/) - Culture-first AI & tech job board with Glassdoor ratings, culture values, and employee reviews for 45+ companies.
 - [Jobtensor](https://jobtensor.com/) - AI, tech, and science job board.


### PR DESCRIPTION
## Summary
- Adds [Robot Jobs Board](https://www.robotjobsboard.com) under AI
- Niche board for robotics and automation roles (AMR, humanoid, drones, ROS) in the US, UK, and Europe

## Why
Specialty robotics hiring is fragmented across ATS boards; this aggregates open roles for candidates looking specifically for robot/automation work.