### PR TITLE
Add Pegel to Germany list

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 - [karrieresprung](https://www.karrieresprung.de/)
 - [JobJump](https://jobjump.net/)
 - [DACH Early-Career Jobs](https://github.com/heynish/werkstudent-praktikum-jobs)
+- [Pegel](https://pegel.berlin/jobs) - Free job board for Berlin startups, updated from public company ATS feeds three times a day.
 
 ### Netherlands
 


### PR DESCRIPTION
Adds Pegel to the Germany section. It is a free job board for Berlin startups and sends applicants back to the employer's original page.

Disclosure: I built and run Pegel.