### PR TITLE
Add InternDoor to India

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,7 @@ You can also check out [open-source-jobs](https://github.com/timqian/open-source
 ### India
 
 - [PrepNPlaced Apprenticeships](https://www.prepnplaced.com/apprenticeships) - Hand-checked Indian tech apprenticeship and early-career programmes, including government and PSU schemes.
+- [InternDoor](https://interndoor.com) - Engineering internships in India, filtered to a vetted list of real employers and updated every 30 minutes.
 
 ### Asia
 


### PR DESCRIPTION
Adding [InternDoor](https://interndoor.com) to the India section.

It's a job board for engineering internships in India. What makes it worth listing rather than being another aggregator: postings are only kept if the employer is on a manually maintained list of real companies, which filters out the certificate-selling "virtual internship" schemes that make up most of what gets posted in this market — currently about 60 listings rejected for every one published.

Around 250 live roles from 141 companies, refreshed every 30 minutes, free and no signup. There's also a daily-updated GitHub mirror at https://github.com/akshat0011/engineering-internship-india if that's more useful.

Added to the bottom of the existing India category, matching the surrounding format.